### PR TITLE
Move feature profiles to xtraplatform-features

### DIFF
--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/profile/ProfileSet.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/profile/ProfileSet.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.features.domain.profile;
+
+import com.github.azahnen.dagger.annotations.AutoMultiBind;
+import de.ii.xtraplatform.features.domain.FeatureSchema;
+import java.util.List;
+import java.util.Optional;
+
+@AutoMultiBind
+public interface ProfileSet {
+
+  /**
+   * @return the prefix of the profile extension
+   */
+  String getPrefix();
+
+  /**
+   * @return the profile values of the profile extension
+   */
+  List<String> getValues();
+
+  /**
+   * @return an optional default value
+   */
+  default Optional<String> getDefault() {
+    return Optional.empty();
+  }
+
+  /**
+   * @param value the profile
+   * @param schema the feature schema
+   * @param mediaType the media type of t
+   * @param builder
+   */
+  void addPropertyTransformations(
+      String value,
+      FeatureSchema schema,
+      String mediaType,
+      ImmutableProfileTransformations.Builder builder);
+}

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/profile/ProfileSetRel.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/profile/ProfileSetRel.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2025 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.features.domain.profile;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import de.ii.xtraplatform.features.domain.FeatureSchema;
+import de.ii.xtraplatform.features.domain.SchemaBase;
+import de.ii.xtraplatform.features.domain.transform.FeatureRefResolver;
+import de.ii.xtraplatform.features.domain.transform.ImmutablePropertyTransformation;
+import java.util.List;
+import java.util.Objects;
+import javax.ws.rs.core.MediaType;
+
+public class ProfileSetRel implements ProfileSet {
+
+  public static final String REL = "rel";
+  public static final String AS_KEY = "rel-as-key";
+  public static final String AS_URI = "rel-as-uri";
+  public static final String AS_LINK = "rel-as-link";
+
+  private static final String URI_TEMPLATE =
+      String.format(
+          "{{%s | orElse:'{{apiUri}}/collections/%s/items/%s'}}",
+          FeatureRefResolver.URI_TEMPLATE, FeatureRefResolver.SUB_TYPE, FeatureRefResolver.SUB_ID);
+
+  private static final String KEY_TEMPLATE =
+      String.format(
+          "{{%s | orElse:'%s::%s'}}",
+          FeatureRefResolver.KEY_TEMPLATE, FeatureRefResolver.SUB_TYPE, FeatureRefResolver.SUB_ID);
+
+  private static final String HTML_LINK_TEMPLATE =
+      String.format("<a href=\"%s\">%s</a>", URI_TEMPLATE, FeatureRefResolver.SUB_TITLE);
+
+  @Override
+  public String getPrefix() {
+    return REL;
+  }
+
+  @Override
+  public List<String> getValues() {
+    return List.of(AS_KEY, AS_URI, AS_LINK);
+  }
+
+  @Override
+  public void addPropertyTransformations(
+      String value,
+      FeatureSchema schema,
+      String mediaType,
+      ImmutableProfileTransformations.Builder builder) {
+    if (!getValues().contains(value)) {
+      return;
+    }
+
+    schema.getAllNestedProperties().stream()
+        .filter(SchemaBase::isFeatureRef)
+        .forEach(
+            property -> {
+              switch (value) {
+                case AS_KEY:
+                  reduceToKey(property, builder);
+                  break;
+                case AS_URI:
+                  reduceToUri(property, builder);
+                  break;
+                case AS_LINK:
+                  if (mediaType.equals(MediaType.TEXT_HTML)) {
+                    reduceToLink(property, builder);
+                  } else {
+                    mapToLink(property, builder);
+                  }
+                  break;
+              }
+            });
+  }
+
+  public static boolean usesFeatureRef(FeatureSchema featuretype) {
+    return featuretype.getAllNestedProperties().stream().anyMatch(SchemaBase::isFeatureRef);
+  }
+
+  public static void reduceToKey(
+      FeatureSchema property, ImmutableProfileTransformations.Builder builder) {
+    builder.putTransformations(
+        property.getFullPathAsString(),
+        ImmutableList.of(
+            property
+                        .getRefType()
+                        .filter(
+                            refType ->
+                                !Objects.equals(refType, FeatureRefResolver.REF_TYPE_DYNAMIC))
+                        .isPresent()
+                    && property.getRefKeyTemplate().isEmpty()
+                ? new ImmutablePropertyTransformation.Builder()
+                    .objectRemoveSelect(FeatureRefResolver.ID)
+                    .objectReduceSelect(FeatureRefResolver.ID)
+                    .build()
+                : new ImmutablePropertyTransformation.Builder()
+                    .objectRemoveSelect(FeatureRefResolver.ID)
+                    .objectReduceFormat(KEY_TEMPLATE)
+                    .build()));
+  }
+
+  public static void reduceToUri(
+      FeatureSchema property, ImmutableProfileTransformations.Builder builder) {
+    builder.putTransformations(
+        property.getFullPathAsString(),
+        ImmutableList.of(
+            new ImmutablePropertyTransformation.Builder()
+                .objectRemoveSelect(FeatureRefResolver.ID)
+                .objectReduceFormat(URI_TEMPLATE)
+                .build()));
+  }
+
+  public static void mapToLink(
+      FeatureSchema property, ImmutableProfileTransformations.Builder builder) {
+    builder.putTransformations(
+        property.getFullPathAsString(),
+        ImmutableList.of(
+            new ImmutablePropertyTransformation.Builder()
+                .objectRemoveSelect(FeatureRefResolver.ID)
+                .objectMapFormat(
+                    ImmutableMap.of("title", FeatureRefResolver.SUB_TITLE, "href", URI_TEMPLATE))
+                .build()));
+  }
+
+  public static void reduceToLink(
+      FeatureSchema property, ImmutableProfileTransformations.Builder builder) {
+    builder.putTransformations(
+        property.getFullPathAsString(),
+        ImmutableList.of(
+            new ImmutablePropertyTransformation.Builder()
+                .objectRemoveSelect(FeatureRefResolver.ID)
+                .objectReduceFormat(HTML_LINK_TEMPLATE)
+                .build()));
+  }
+}

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/profile/ProfileSetVal.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/profile/ProfileSetVal.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.features.domain.profile;
+
+import com.google.common.collect.ImmutableList;
+import de.ii.xtraplatform.features.domain.FeatureSchema;
+import de.ii.xtraplatform.features.domain.SchemaConstraints;
+import de.ii.xtraplatform.features.domain.transform.ImmutablePropertyTransformation;
+import java.util.List;
+
+public class ProfileSetVal implements ProfileSet {
+
+  public static final String VAL = "val";
+  public static final String AS_CODE = "val-as-code";
+  public static final String AS_TITLE = "val-as-title";
+
+  @Override
+  public String getPrefix() {
+    return VAL;
+  }
+
+  @Override
+  public List<String> getValues() {
+    return List.of(AS_CODE, AS_TITLE);
+  }
+
+  @Override
+  public void addPropertyTransformations(
+      String value,
+      FeatureSchema schema,
+      String mediaType,
+      ImmutableProfileTransformations.Builder builder) {
+    if (!getValues().contains(value)) {
+      return;
+    }
+
+    if (AS_TITLE.equals(value)) {
+      schema.getAllNestedProperties().stream()
+          .filter(p -> p.getConstraints().map(c -> c.getCodelist().isPresent()).orElse(false))
+          .forEach(property -> mapToTitle(property, builder));
+    }
+  }
+
+  public static boolean usesCodedValue(FeatureSchema featuretype) {
+    // only consider codelist transformations in the provider constraints as the other
+    // transformations are fixed and cannot be disabled.
+    return featuretype.getAllNestedProperties().stream()
+        .anyMatch(p -> p.getConstraints().flatMap(SchemaConstraints::getCodelist).isPresent());
+  }
+
+  public static void mapToTitle(
+      FeatureSchema property, ImmutableProfileTransformations.Builder builder) {
+    property
+        .getConstraints()
+        .flatMap(SchemaConstraints::getCodelist)
+        .ifPresent(
+            codelist -> {
+              builder.putTransformations(
+                  property.getFullPathAsString(),
+                  ImmutableList.of(
+                      new ImmutablePropertyTransformation.Builder().codelist(codelist).build()));
+            });
+  }
+}

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/profile/ProfileTransformations.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/profile/ProfileTransformations.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2025 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.features.domain.profile;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import de.ii.xtraplatform.features.domain.transform.PropertyTransformations;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Value.Style(builder = "new")
+@JsonDeserialize(builder = ImmutableProfileTransformations.Builder.class)
+public interface ProfileTransformations extends PropertyTransformations {}

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeaturePropertyTransformerCodelist.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeaturePropertyTransformerCodelist.java
@@ -7,9 +7,13 @@
  */
 package de.ii.xtraplatform.features.domain.transform;
 
+import com.google.common.collect.ImmutableList;
 import de.ii.xtraplatform.codelists.domain.Codelist;
 import de.ii.xtraplatform.codelists.domain.Codelist.ImportType;
+import de.ii.xtraplatform.features.domain.SchemaBase;
+import de.ii.xtraplatform.features.domain.SchemaBase.Type;
 import de.ii.xtraplatform.strings.domain.StringTemplateFilters;
+import java.util.List;
 import java.util.Map;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
@@ -20,6 +24,11 @@ public interface FeaturePropertyTransformerCodelist extends FeaturePropertyValue
 
   Logger LOGGER = LoggerFactory.getLogger(FeaturePropertyTransformerCodelist.class);
   String TYPE = "CODELIST";
+
+  @Override
+  default List<Type> getSupportedPropertyTypes() {
+    return ImmutableList.of(SchemaBase.Type.STRING, SchemaBase.Type.INTEGER);
+  }
 
   @Override
   default String getType() {

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeaturePropertyTransformerValueType.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/FeaturePropertyTransformerValueType.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.features.domain.transform;
+
+import de.ii.xtraplatform.features.domain.FeatureSchema;
+import de.ii.xtraplatform.features.domain.ImmutableFeatureSchema;
+import de.ii.xtraplatform.features.domain.SchemaBase.Type;
+import java.util.Objects;
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface FeaturePropertyTransformerValueType extends FeaturePropertySchemaTransformer {
+
+  String TYPE = "VALUE_TYPE";
+
+  @Override
+  default String getType() {
+    return TYPE;
+  }
+
+  @Override
+  default FeatureSchema transform(String currentPropertyPath, FeatureSchema schema) {
+    Type type = Type.valueOf(getParameter());
+    if (Objects.equals(currentPropertyPath, getPropertyPath())
+        && !Objects.equals(schema.getType(), type)) {
+      return new ImmutableFeatureSchema.Builder().from(schema).type(type).build();
+    }
+
+    return schema;
+  }
+}

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/SchemaTransformerChain.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/SchemaTransformerChain.java
@@ -11,6 +11,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import de.ii.xtraplatform.features.domain.FeatureSchema;
 import de.ii.xtraplatform.features.domain.ImmutableFeatureSchema;
+import de.ii.xtraplatform.features.domain.SchemaBase;
 import de.ii.xtraplatform.features.domain.SchemaMapping;
 import de.ii.xtraplatform.features.domain.SchemaVisitorTopDown;
 import java.util.AbstractMap.SimpleEntry;
@@ -182,6 +183,16 @@ public class SchemaTransformerChain
                               .propertyPath(path)
                               .parameter(remove)
                               .inCollection(inCollection)
+                              .build()));
+
+          propertyTransformation
+              .getCodelist()
+              .ifPresent(
+                  codelist ->
+                      transformers.add(
+                          ImmutableFeaturePropertyTransformerValueType.builder()
+                              .propertyPath(path)
+                              .parameter(SchemaBase.Type.STRING.name())
                               .build()));
         });
 

--- a/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/domain/TileGenerationOptions.java
+++ b/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/domain/TileGenerationOptions.java
@@ -82,4 +82,13 @@ public interface TileGenerationOptions {
    * @since v3.4
    */
   Map<String, List<LevelTransformation>> getTransformations();
+
+  /**
+   * @langEn The feature profiles to be applied when generating features for the tileset.
+   * @langDe Die Feature-Profile, die bei der Erstellung von Features für das Tileset angewendet
+   *     werden sollen.
+   * @default []
+   * @since v4.3
+   */
+  List<String> getProfiles();
 }

--- a/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/domain/TilesetFeatures.java
+++ b/xtraplatform-tiles/src/main/java/de/ii/xtraplatform/tiles/domain/TilesetFeatures.java
@@ -73,6 +73,10 @@ public interface TilesetFeatures
   @Override
   Map<String, List<LevelTransformation>> getTransformations();
 
+  @DocIgnore
+  @Override
+  List<String> getProfiles();
+
   /**
    * @langEn The name of the feature type. By default the tileset id is used.
    * @langDe Der Name des Feature-Types. Standardmäßig wird die Tileset-Id verwendet.
@@ -135,6 +139,9 @@ public interface TilesetFeatures
     }
     if (this.getTransformations().isEmpty()) {
       withDefaults.transformations(defaults.getTransformations());
+    }
+    if (this.getProfiles().isEmpty()) {
+      withDefaults.profiles(defaults.getProfiles());
     }
     if (Objects.isNull(this.getFeatureLimit()) && Objects.nonNull(defaults.getFeatureLimit())) {
       withDefaults.featureLimit(defaults.getFeatureLimit());


### PR DESCRIPTION
Move the profiles and their associated property transformations to xtraplatform-features. All aspects related to API building block stays in ldproxy.

This PR also adds support for profiles in Vector Tiles generated from a feature provider. The profiles to be applied are declared in the tileset of a tile provider as an array with the key `profiles`. If declared in the tileset defaults, the profile will apply to all tilesets.

A new transformer was introduced to change the type of a codelist property (which may be an integer) to string to correctly represent the value type (otherwise the value is not encoded in the vector tile, because the actual type differs from the expected type).

Related to https://github.com/ldproxy/ldproxy/issues/1328.