### PR TITLE
SQL feature provider: add nullOrder option

### DIFF
--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSql.java
@@ -521,7 +521,8 @@ public class FeatureProviderSql
                                           filterEncoder,
                                           sqlDialect,
                                           getData().getQueryGeneration().getComputeNumberMatched(),
-                                          true)))
+                                          true,
+                                          getData().getQueryGeneration().getNullOrder())))
                           .collect(Collectors.toList()));
                 })
             .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
@@ -544,7 +545,8 @@ public class FeatureProviderSql
                                         filterEncoder,
                                         sqlDialect,
                                         getData().getQueryGeneration().getComputeNumberMatched(),
-                                        false)))))
+                                        false,
+                                        getData().getQueryGeneration().getNullOrder())))))
             .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
 
     this.queryTransformer =

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSqlData.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSqlData.java
@@ -138,6 +138,11 @@ public interface FeatureProviderSqlData
   @JsonDeserialize(builder = ImmutableQueryGeneratorSettings.Builder.class)
   interface QueryGeneratorSettings {
 
+    enum NullOrder {
+      FIRST,
+      LAST
+    }
+
     @DocIgnore
     @Value.Default
     default int getChunkSize() {
@@ -157,6 +162,22 @@ public interface FeatureProviderSqlData
     @Value.Default
     default boolean getComputeNumberMatched() {
       return true;
+    }
+
+    /**
+     * @langEn If no value is provided, the sort order of the underlying feature provider (typically
+     *     `last` for ascending and `first` for descending) is used. `last` or `first` can be used
+     *     to force a specific sort order, if some rows have null values.
+     * @langDe Ohne Angabe wird die Sortierreihenfolge des zugrunde liegenden Feature-Providers
+     *     verwendet (normalerweise `last` für aufsteigend und `first` für absteigend). `last` oder
+     *     `first` kann verwendet werden, um eine bestimmte Sortierreihenfolge für Spalten mit
+     *     Nullwerten zu erzwingen.
+     * @default -
+     * @since v4.3
+     */
+    @Value.Default
+    default Optional<NullOrder> getNullOrder() {
+      return Optional.empty();
     }
 
     // TODO

--- a/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/SqlQueryTemplatesDeriverSpec.groovy
+++ b/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/SqlQueryTemplatesDeriverSpec.groovy
@@ -29,9 +29,9 @@ class SqlQueryTemplatesDeriverSpec extends Specification {
     @Shared
     FilterEncoderSql filterEncoder = new FilterEncoderSql(OgcCrs.CRS84, new SqlDialectPgis(), null, null, new CqlImpl(), null)
     @Shared
-    SqlQueryTemplatesDeriver td = new SqlQueryTemplatesDeriver(null, filterEncoder, new SqlDialectPgis(), true, false)
+    SqlQueryTemplatesDeriver td = new SqlQueryTemplatesDeriver(null, filterEncoder, new SqlDialectPgis(), true, false, Optional.empty())
     @Shared
-    SqlQueryTemplatesDeriver tdNoNm = new SqlQueryTemplatesDeriver(null, filterEncoder, new SqlDialectPgis(), false, false)
+    SqlQueryTemplatesDeriver tdNoNm = new SqlQueryTemplatesDeriver(null, filterEncoder, new SqlDialectPgis(), false, false, Optional.empty())
 
     @Shared
     QuerySchemaDeriver schemaDeriver


### PR DESCRIPTION
This change adds a query generation option `nullOrder` to SQL feature providers to control the sort order for columns with null values. If no value is provided, the default order of the database applies. For `last`, the rows with `null` always are last for both ascending and descending. For `first`, the rows with `null` are always first. This is implemented by adding `NULLS LAST` or `NULLS FIRST` to each sort field.

Example: 

```yaml
queryGeneration: 
  nullOrder: last
```