### PR TITLE
Support wkb geometries

### DIFF
--- a/xtraplatform-features-oracle/src/main/java/de/ii/xtraplatform/features/oracle/app/SqlDialectOras.java
+++ b/xtraplatform-features-oracle/src/main/java/de/ii/xtraplatform/features/oracle/app/SqlDialectOras.java
@@ -60,7 +60,7 @@ public class SqlDialectOras implements SqlDialect {
 
   @Override
   public String applyToWkb(byte[] wkb, int srid) {
-    return "SDO_UTIL.FROM_WKBGEOMETRY(?, ?)";
+    return String.format("GeomFromWKB('%s', %d)", wkb, srid);
   }
 
   @Override

--- a/xtraplatform-features-oracle/src/main/java/de/ii/xtraplatform/features/oracle/app/SqlDialectOras.java
+++ b/xtraplatform-features-oracle/src/main/java/de/ii/xtraplatform/features/oracle/app/SqlDialectOras.java
@@ -37,34 +37,6 @@ public class SqlDialectOras implements SqlDialect {
 
   private QueryGeneratorSettings settings;
 
-  /*
-    private String applyToGeometry(String column, boolean forcePolygonCCW, boolean linearizeCurves) {
-      if (settings.getGeometryAsWkb()) {
-        return applyToWkb(column, forcePolygonCCW, linearizeCurves);
-      } else {
-        return applyToWkt(column, forcePolygonCCW, linearizeCurves);
-      }
-    }
-
-    private String applyToGeometry(Object geometry, int srid) {
-      if (settings.getGeometryAsWkb()) {
-        if (geometry instanceof byte[]) {
-          return applyToWkb((byte[]) geometry, srid);
-        } else if (geometry instanceof String) {
-          byte[] wkb = ((String) geometry).getBytes(); // Convert the geometry string to a byte array
-          return applyToWkb(wkb, srid);
-        } else {
-          throw new IllegalArgumentException("Expected geometry to be either byte[] or String.");
-        }
-      } else {
-        if (geometry instanceof String) {
-          return applyToWkt((String) geometry, srid);
-        } else {
-          throw new IllegalArgumentException("Expected geometry to be a String for WKT format.");
-        }
-      }
-    }
-  */
   @Override
   public String applyToWkt(String column, boolean forcePolygonCCW, boolean linearizeCurves) {
     if (!forcePolygonCCW) {
@@ -167,7 +139,6 @@ public class SqlDialectOras implements SqlDialect {
   public String applyToInstantMin() {
     return "0001-01-01T00:00:00Z";
   }
-  ;
 
   @Override
   public String applyToInstantMax() {

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/FilterEncoderSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/FilterEncoderSql.java
@@ -66,6 +66,8 @@ import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import org.locationtech.jts.io.WKBWriter;
+import org.locationtech.jts.io.WKTReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.threeten.extra.Interval;
@@ -83,6 +85,7 @@ public class FilterEncoderSql {
   private final CrsInfo crsInfo;
   private final Cql cql;
   private final String accentiCollation;
+  private final boolean geometryAsWkb;
   BiFunction<List<Double>, Optional<EpsgCrs>, List<Double>> coordinatesTransformer;
 
   public FilterEncoderSql(
@@ -91,7 +94,8 @@ public class FilterEncoderSql {
       CrsTransformerFactory crsTransformerFactory,
       CrsInfo crsInfo,
       Cql cql,
-      String accentiCollation) {
+      String accentiCollation,
+      boolean geometryAsWkb) {
     this.nativeCrs = nativeCrs;
     this.sqlDialect = sqlDialect;
     this.crsTransformerFactory = crsTransformerFactory;
@@ -99,6 +103,7 @@ public class FilterEncoderSql {
     this.cql = cql;
     this.accentiCollation = accentiCollation;
     this.coordinatesTransformer = this::transformCoordinatesIfNecessary;
+    this.geometryAsWkb = geometryAsWkb;
   }
 
   public String encode(Cql2Expression cqlFilter, SchemaSql schema) {
@@ -250,10 +255,11 @@ public class FilterEncoderSql {
                 }
                 String qualifiedColumn = String.format("%s.%s", alias, column.getName());
                 if (column.isTemporal()) {
-                  if (column.getType() == DATE)
+                  if (column.getType() == DATE) {
                     return Tuple.of(
                         sqlDialect.applyToDate(qualifiedColumn, column.getFormat()),
                         Optional.<String>empty());
+                  }
                   return Tuple.of(
                       sqlDialect.applyToDatetime(qualifiedColumn, column.getFormat()),
                       Optional.<String>empty());
@@ -348,7 +354,9 @@ public class FilterEncoderSql {
               ignoreInstanceFilter,
               true,
               FilterEncoderSql.this);
-      if (!join.isEmpty()) join = join + " ";
+      if (!join.isEmpty()) {
+        join = join + " ";
+      }
 
       return String.format(
           "A.%3$s IN (SELECT %2$s.%3$s FROM %1$s %2$s %4$sWHERE %%1$s%5$s%%2$s)",
@@ -389,18 +397,21 @@ public class FilterEncoderSql {
       String end = children.get(1);
 
       // process special values for a half-bounded interval
-      if (start.equals("'..'"))
+      if (start.equals("'..'")) {
         start = sqlDialect.applyToDatetimeLiteral(sqlDialect.applyToInstantMin());
-      if (end.equals("'..'"))
+      }
+      if (end.equals("'..'")) {
         end = sqlDialect.applyToDatetimeLiteral(sqlDialect.applyToInstantMax());
+      }
 
       Operand arg1 = interval.getArgs().get(0);
       Operand arg2 = interval.getArgs().get(1);
       if (arg1 instanceof Property && arg2 instanceof Property) {
         String startColumn = reduceToColumn(start);
         String endColumn = reduceToColumn(end);
-        if (startColumn.equals(endColumn))
+        if (startColumn.equals(endColumn)) {
           return String.format(start, "%1$s(", ", " + endColumn + ")%2$s");
+        }
         startColumn =
             String.format(
                 "COALESCE(%s,%s)",
@@ -457,8 +468,9 @@ public class FilterEncoderSql {
     @Override
     public String visit(de.ii.xtraplatform.cql.domain.Accenti accenti, List<String> children) {
       if (accenti.getValue() instanceof ScalarLiteral) {
-        if (Objects.nonNull(accentiCollation))
+        if (Objects.nonNull(accentiCollation)) {
           return String.format("%s COLLATE \"%s\"", children.get(0), accentiCollation);
+        }
         throw new IllegalArgumentException("ACCENTI() is not supported by this API.");
       }
       if (Objects.nonNull(accentiCollation)) {
@@ -503,13 +515,14 @@ public class FilterEncoderSql {
     }
 
     private String reduceSelectToColumn(String expression) {
-      if (expression.contains("%1$s") && expression.contains("%2$s"))
+      if (expression.contains("%1$s") && expression.contains("%2$s")) {
         return String.format(
             expression.contains(" WHERE ")
                 ? expression.substring(expression.indexOf(" WHERE ") + 7, expression.length() - 1)
                 : expression,
             "",
             "");
+      }
       return expression;
     }
 
@@ -569,8 +582,12 @@ public class FilterEncoderSql {
       boolean op2hasSelect = operandHasSelect(secondExpression);
       boolean op3hasSelect = operandHasSelect(thirdExpression);
       if (op1hasSelect) {
-        if (op2hasSelect) secondExpression = reduceSelectToColumn(children.get(1));
-        if (op3hasSelect) thirdExpression = reduceSelectToColumn(children.get(2));
+        if (op2hasSelect) {
+          secondExpression = reduceSelectToColumn(children.get(1));
+        }
+        if (op3hasSelect) {
+          thirdExpression = reduceSelectToColumn(children.get(2));
+        }
       } else {
         // the unusual case that a literal is on the left side
         if (op2hasSelect && !op3hasSelect) {
@@ -690,9 +707,10 @@ public class FilterEncoderSql {
     @Override
     public String visit(BinaryTemporalOperation temporalOperation, List<String> children) {
       String operator = sqlDialect.getTemporalOperator(temporalOperation.getTemporalOperator());
-      if (Objects.isNull(operator))
+      if (Objects.isNull(operator)) {
         throw new IllegalStateException(
             String.format("unexpected temporal operator: %s", temporalOperation.getClass()));
+      }
 
       Temporal op1 = (Temporal) temporalOperation.getArgs().get(0);
       Temporal op2 = (Temporal) temporalOperation.getArgs().get(1);
@@ -771,10 +789,11 @@ public class FilterEncoderSql {
 
     private String getStartAsString(TemporalLiteral literal) {
       Object start = getStart(literal);
-      if (start instanceof Instant && start == Instant.MIN)
+      if (start instanceof Instant && start == Instant.MIN) {
         return sqlDialect.applyToDatetimeLiteral(sqlDialect.applyToInstantMin());
-      else if (start instanceof LocalDate)
+      } else if (start instanceof LocalDate) {
         return sqlDialect.applyToDateLiteral(DateTimeFormatter.ISO_DATE.format((LocalDate) start));
+      }
       return sqlDialect.applyToDatetimeLiteral(start.toString());
     }
 
@@ -798,10 +817,11 @@ public class FilterEncoderSql {
 
     private String getEndExclusiveAsString(TemporalLiteral literal) {
       Object end = getEndExclusive(literal);
-      if (end instanceof Instant && end == Instant.MAX)
+      if (end instanceof Instant && end == Instant.MAX) {
         return sqlDialect.applyToDatetimeLiteral(sqlDialect.applyToInstantMax());
-      else if (end instanceof LocalDate)
+      } else if (end instanceof LocalDate) {
         return sqlDialect.applyToDateLiteral(DateTimeFormatter.ISO_DATE.format((LocalDate) end));
+      }
       return sqlDialect.applyToDatetimeLiteral(end.toString());
     }
 
@@ -830,9 +850,13 @@ public class FilterEncoderSql {
       if (temporalLiteral.getType() == Instant.class) {
         Instant instant = ((Instant) temporalLiteral.getValue());
         String literal;
-        if (instant == Instant.MIN) literal = sqlDialect.applyToInstantMin();
-        else if (instant == Instant.MAX) literal = sqlDialect.applyToInstantMax();
-        else literal = ((Instant) temporalLiteral.getValue()).toString();
+        if (instant == Instant.MIN) {
+          literal = sqlDialect.applyToInstantMin();
+        } else if (instant == Instant.MAX) {
+          literal = sqlDialect.applyToInstantMax();
+        } else {
+          literal = ((Instant) temporalLiteral.getValue()).toString();
+        }
         return sqlDialect.applyToDatetimeLiteral(literal);
       } else if (temporalLiteral.getType() == Interval.class) {
         // this can only occur in the T_INTERSECTS() operator
@@ -864,60 +888,129 @@ public class FilterEncoderSql {
 
     @Override
     public String visit(Geometry.Point point, List<String> children) {
-      return sqlDialect.applyToWkt(super.visit(point, children), nativeCrs.getCode());
+      if (geometryAsWkb) {
+        byte[] wkb = convertToWkb(super.visit(point, children));
+        return sqlDialect.applyToWkb(wkb, nativeCrs.getCode());
+      } else {
+        return sqlDialect.applyToWkt(super.visit(point, children), nativeCrs.getCode());
+      }
     }
 
     @Override
     public String visit(Geometry.LineString lineString, List<String> children) {
-      return sqlDialect.applyToWkt(super.visit(lineString, children), nativeCrs.getCode());
+      if (geometryAsWkb) {
+        byte[] wkb = convertToWkb(super.visit(lineString, children));
+        return sqlDialect.applyToWkb(wkb, nativeCrs.getCode());
+      } else {
+        return sqlDialect.applyToWkt(super.visit(lineString, children), nativeCrs.getCode());
+      }
     }
 
     @Override
     public String visit(Geometry.Polygon polygon, List<String> children) {
-      return sqlDialect.applyToWkt(super.visit(polygon, children), nativeCrs.getCode());
+      if (geometryAsWkb) {
+        byte[] wkb = convertToWkb(super.visit(polygon, children));
+        return sqlDialect.applyToWkb(wkb, nativeCrs.getCode());
+      } else {
+        return sqlDialect.applyToWkt(super.visit(polygon, children), nativeCrs.getCode());
+      }
     }
 
     @Override
     public String visit(Geometry.MultiPoint multiPoint, List<String> children) {
-      return sqlDialect.applyToWkt(super.visit(multiPoint, children), nativeCrs.getCode());
+      if (geometryAsWkb) {
+        byte[] wkb = convertToWkb(super.visit(multiPoint, children));
+        return sqlDialect.applyToWkb(wkb, nativeCrs.getCode());
+      } else {
+        return sqlDialect.applyToWkt(super.visit(multiPoint, children), nativeCrs.getCode());
+      }
     }
 
     @Override
     public String visit(Geometry.MultiLineString multiLineString, List<String> children) {
-      return sqlDialect.applyToWkt(super.visit(multiLineString, children), nativeCrs.getCode());
+      if (geometryAsWkb) {
+        byte[] wkb = convertToWkb(super.visit(multiLineString, children));
+        return sqlDialect.applyToWkb(wkb, nativeCrs.getCode());
+      } else {
+        return sqlDialect.applyToWkt(super.visit(multiLineString, children), nativeCrs.getCode());
+      }
     }
 
     @Override
     public String visit(Geometry.MultiPolygon multiPolygon, List<String> children) {
-      return sqlDialect.applyToWkt(super.visit(multiPolygon, children), nativeCrs.getCode());
+      if (geometryAsWkb) {
+        byte[] wkb = convertToWkb(super.visit(multiPolygon, children));
+        return sqlDialect.applyToWkb(wkb, nativeCrs.getCode());
+      } else {
+        return sqlDialect.applyToWkt(super.visit(multiPolygon, children), nativeCrs.getCode());
+      }
     }
 
     @Override
     public String visit(Geometry.GeometryCollection geometryCollection, List<String> children) {
-      return sqlDialect.applyToWkt(
-          String.format(
-              "GEOMETRYCOLLECTION%s",
-              geometryCollection.getCoordinates().stream()
-                  .map(
-                      geom -> {
-                        if (geom instanceof Geometry.Point) {
-                          return super.visit((Geometry.Point) geom, children);
-                        } else if (geom instanceof Geometry.MultiPoint) {
-                          return super.visit((Geometry.MultiPoint) geom, children);
-                        } else if (geom instanceof Geometry.LineString) {
-                          return super.visit((Geometry.LineString) geom, children);
-                        } else if (geom instanceof Geometry.MultiLineString) {
-                          return super.visit((Geometry.MultiLineString) geom, children);
-                        } else if (geom instanceof Geometry.Polygon) {
-                          return super.visit((Geometry.Polygon) geom, children);
-                        } else if (geom instanceof Geometry.MultiPolygon) {
-                          return super.visit((Geometry.MultiPolygon) geom, children);
-                        }
-                        throw new IllegalStateException(
-                            "unsupported spatial type: " + geom.getClass().getSimpleName());
-                      })
-                  .collect(Collectors.joining(",", "(", ")"))),
-          nativeCrs.getCode());
+      if (geometryAsWkb) {
+        byte[] wkb =
+            convertToWkb(
+                String.format(
+                    "GEOMETRYCOLLECTION%s",
+                    geometryCollection.getCoordinates().stream()
+                        .map(
+                            geom -> {
+                              if (geom instanceof Geometry.Point) {
+                                return super.visit((Geometry.Point) geom, children);
+                              } else if (geom instanceof Geometry.MultiPoint) {
+                                return super.visit((Geometry.MultiPoint) geom, children);
+                              } else if (geom instanceof Geometry.LineString) {
+                                return super.visit((Geometry.LineString) geom, children);
+                              } else if (geom instanceof Geometry.MultiLineString) {
+                                return super.visit((Geometry.MultiLineString) geom, children);
+                              } else if (geom instanceof Geometry.Polygon) {
+                                return super.visit((Geometry.Polygon) geom, children);
+                              } else if (geom instanceof Geometry.MultiPolygon) {
+                                return super.visit((Geometry.MultiPolygon) geom, children);
+                              }
+                              throw new IllegalStateException(
+                                  "unsupported spatial type: " + geom.getClass().getSimpleName());
+                            })
+                        .collect(Collectors.joining(",", "(", ")"))));
+        return sqlDialect.applyToWkb(wkb, nativeCrs.getCode());
+      } else {
+        return sqlDialect.applyToWkt(
+            String.format(
+                "GEOMETRYCOLLECTION%s",
+                geometryCollection.getCoordinates().stream()
+                    .map(
+                        geom -> {
+                          if (geom instanceof Geometry.Point) {
+                            return super.visit((Geometry.Point) geom, children);
+                          } else if (geom instanceof Geometry.MultiPoint) {
+                            return super.visit((Geometry.MultiPoint) geom, children);
+                          } else if (geom instanceof Geometry.LineString) {
+                            return super.visit((Geometry.LineString) geom, children);
+                          } else if (geom instanceof Geometry.MultiLineString) {
+                            return super.visit((Geometry.MultiLineString) geom, children);
+                          } else if (geom instanceof Geometry.Polygon) {
+                            return super.visit((Geometry.Polygon) geom, children);
+                          } else if (geom instanceof Geometry.MultiPolygon) {
+                            return super.visit((Geometry.MultiPolygon) geom, children);
+                          }
+                          throw new IllegalStateException(
+                              "unsupported spatial type: " + geom.getClass().getSimpleName());
+                        })
+                    .collect(Collectors.joining(",", "(", ")"))),
+            nativeCrs.getCode());
+      }
+    }
+
+    private byte[] convertToWkb(String wkt) {
+      try {
+        WKTReader reader = new WKTReader();
+        org.locationtech.jts.geom.Geometry geometry = reader.read(wkt);
+        WKBWriter writer = new WKBWriter();
+        return writer.write(geometry);
+      } catch (Exception e) {
+        throw new IllegalArgumentException("Invalid WKT format", e);
+      }
     }
 
     @Override
@@ -978,7 +1071,9 @@ public class FilterEncoderSql {
                   : "1=0";
             case A_EQUALS:
               // items must be identical
-              if (firstOp.size() != secondOp.size()) return "1=0";
+              if (firstOp.size() != secondOp.size()) {
+                return "1=0";
+              }
               return secondOp.stream()
                       .allMatch(item -> firstOp.stream().anyMatch(item2 -> item.equals(item2)))
                   ? "1=1"

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/GeometryDecoderWkb.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/GeometryDecoderWkb.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2025 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.features.sql.app;
+
+import de.ii.xtraplatform.features.domain.FeatureEventHandler;
+import de.ii.xtraplatform.features.domain.FeatureEventHandler.ModifiableContext;
+import de.ii.xtraplatform.features.domain.FeatureSchema;
+import de.ii.xtraplatform.features.domain.SchemaBase.Type;
+import de.ii.xtraplatform.features.domain.SchemaMapping;
+import de.ii.xtraplatform.geometries.domain.SimpleFeatureGeometry;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.OptionalInt;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.WKBReader;
+
+public class GeometryDecoderWkb {
+
+  private final FeatureEventHandler<
+          FeatureSchema, SchemaMapping, ModifiableContext<FeatureSchema, SchemaMapping>>
+      handler;
+  private final ModifiableContext<FeatureSchema, SchemaMapping> context;
+  private final WKBReader wkbReader;
+
+  public GeometryDecoderWkb(
+      FeatureEventHandler<
+              FeatureSchema, SchemaMapping, ModifiableContext<FeatureSchema, SchemaMapping>>
+          handler,
+      ModifiableContext<FeatureSchema, SchemaMapping> context) {
+    this.handler = handler;
+    this.context = context;
+    this.wkbReader = new WKBReader();
+  }
+
+  public void decode(byte[] wkb) throws IOException {
+    try {
+      Geometry geometry = wkbReader.read(wkb);
+      SimpleFeatureGeometry geometryType = SimpleFeatureGeometryFromToWkb.fromGeometry(geometry);
+      int dimension = geometry.getCoordinate().z != Double.NaN ? 3 : 2;
+
+      if (!geometryType.isValid()) {
+        return;
+      }
+
+      context.setGeometryType(geometryType);
+      context.setGeometryDimension(dimension);
+      handler.onObjectStart(context);
+      context.setInGeometry(true);
+
+      switch (geometryType) {
+        case POINT:
+          handlePoint(geometry);
+          break;
+        case MULTI_POINT:
+          handleMultiPoint(geometry);
+          break;
+        case LINE_STRING:
+          handleLineString(geometry);
+          break;
+        case MULTI_LINE_STRING:
+          handleMultiLineString(geometry);
+          break;
+        case POLYGON:
+          handlePolygon(geometry);
+          break;
+        case MULTI_POLYGON:
+          handleMultiPolygon(geometry);
+          break;
+        case GEOMETRY_COLLECTION:
+          handleGeometryCollection(geometry);
+          break;
+      }
+
+      context.setInGeometry(false);
+      handler.onObjectEnd(context);
+      context.setGeometryType(Optional.empty());
+      context.setGeometryDimension(OptionalInt.empty());
+    } catch (Exception e) {
+      throw new IOException("Failed to decode WKB", e);
+    }
+  }
+
+  private void handlePoint(Geometry geometry) {
+    context.setValueType(Type.STRING);
+    context.setValue(geometry.toText());
+    handler.onValue(context);
+  }
+
+  private void handleMultiPoint(Geometry geometry) {
+    handler.onArrayStart(context);
+    for (int i = 0; i < geometry.getNumGeometries(); i++) {
+      handlePoint(geometry.getGeometryN(i));
+    }
+    handler.onArrayEnd(context);
+  }
+
+  private void handleLineString(Geometry geometry) {
+    context.setValueType(Type.STRING);
+    context.setValue(geometry.toText());
+    handler.onValue(context);
+  }
+
+  private void handleMultiLineString(Geometry geometry) {
+    handler.onArrayStart(context);
+    for (int i = 0; i < geometry.getNumGeometries(); i++) {
+      handleLineString(geometry.getGeometryN(i));
+    }
+    handler.onArrayEnd(context);
+  }
+
+  private void handlePolygon(Geometry geometry) {
+    context.setValueType(Type.STRING);
+    context.setValue(geometry.toText());
+    handler.onValue(context);
+  }
+
+  private void handleMultiPolygon(Geometry geometry) {
+    handler.onArrayStart(context);
+    for (int i = 0; i < geometry.getNumGeometries(); i++) {
+      handlePolygon(geometry.getGeometryN(i));
+    }
+    handler.onArrayEnd(context);
+  }
+
+  private void handleGeometryCollection(Geometry geometry) {
+    handler.onArrayStart(context);
+    for (int i = 0; i < geometry.getNumGeometries(); i++) {
+      Geometry subGeometry = geometry.getGeometryN(i);
+      SimpleFeatureGeometry subGeometryType =
+          SimpleFeatureGeometryFromToWkb.fromGeometry(subGeometry);
+      switch (subGeometryType) {
+        case POINT:
+          handlePoint(subGeometry);
+          break;
+        case MULTI_POINT:
+          handleMultiPoint(subGeometry);
+          break;
+        case LINE_STRING:
+          handleLineString(subGeometry);
+          break;
+        case MULTI_LINE_STRING:
+          handleMultiLineString(subGeometry);
+          break;
+        case POLYGON:
+          handlePolygon(subGeometry);
+          break;
+        case MULTI_POLYGON:
+          handleMultiPolygon(subGeometry);
+          break;
+        case GEOMETRY_COLLECTION:
+          handleGeometryCollection(subGeometry);
+          break;
+      }
+    }
+    handler.onArrayEnd(context);
+  }
+}

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/GeometryDecoderWkb.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/GeometryDecoderWkb.java
@@ -72,7 +72,6 @@ public class GeometryDecoderWkb {
           handleMultiPolygon(geometry);
           break;
         case GEOMETRY_COLLECTION:
-          handleGeometryCollection(geometry);
           break;
       }
 
@@ -123,39 +122,6 @@ public class GeometryDecoderWkb {
     handler.onArrayStart(context);
     for (int i = 0; i < geometry.getNumGeometries(); i++) {
       handlePolygon(geometry.getGeometryN(i));
-    }
-    handler.onArrayEnd(context);
-  }
-
-  private void handleGeometryCollection(Geometry geometry) {
-    handler.onArrayStart(context);
-    for (int i = 0; i < geometry.getNumGeometries(); i++) {
-      Geometry subGeometry = geometry.getGeometryN(i);
-      SimpleFeatureGeometry subGeometryType =
-          SimpleFeatureGeometryFromToWkb.fromGeometry(subGeometry);
-      switch (subGeometryType) {
-        case POINT:
-          handlePoint(subGeometry);
-          break;
-        case MULTI_POINT:
-          handleMultiPoint(subGeometry);
-          break;
-        case LINE_STRING:
-          handleLineString(subGeometry);
-          break;
-        case MULTI_LINE_STRING:
-          handleMultiLineString(subGeometry);
-          break;
-        case POLYGON:
-          handlePolygon(subGeometry);
-          break;
-        case MULTI_POLYGON:
-          handleMultiPolygon(subGeometry);
-          break;
-        case GEOMETRY_COLLECTION:
-          handleGeometryCollection(subGeometry);
-          break;
-      }
     }
     handler.onArrayEnd(context);
   }

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/SimpleFeatureGeometryFromToWkb.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/SimpleFeatureGeometryFromToWkb.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.features.sql.app;
+
+import de.ii.xtraplatform.geometries.domain.SimpleFeatureGeometry;
+import org.locationtech.jts.geom.Geometry;
+
+public enum SimpleFeatureGeometryFromToWkb {
+  POINT,
+  MULTIPOINT,
+  LINESTRING,
+  MULTILINESTRING,
+  POLYGON,
+  MULTIPOLYGON,
+  GEOMETRYCOLLECTION,
+  ANY,
+  NONE;
+
+  public static SimpleFeatureGeometry fromGeometry(Geometry geometry) {
+    // Implement the logic to convert a Geometry to SimpleFeatureGeometry
+    switch (geometry.getGeometryType().toUpperCase()) {
+      case "POINT":
+        return SimpleFeatureGeometry.POINT;
+      case "MULTIPOINT":
+        return SimpleFeatureGeometry.MULTI_POINT;
+      case "LINESTRING":
+        return SimpleFeatureGeometry.LINE_STRING;
+      case "MULTILINESTRING":
+        return SimpleFeatureGeometry.MULTI_LINE_STRING;
+      case "POLYGON":
+        return SimpleFeatureGeometry.POLYGON;
+      case "MULTIPOLYGON":
+        return SimpleFeatureGeometry.MULTI_POLYGON;
+      case "GEOMETRYCOLLECTION":
+        return SimpleFeatureGeometry.GEOMETRY_COLLECTION;
+      default:
+        return SimpleFeatureGeometry.NONE;
+    }
+  }
+}

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSql.java
@@ -135,31 +135,29 @@ import org.threeten.extra.Interval;
  *     <p>For `PGIS` the following known limitations exist:
  *     <p><code>
  * - Not all CQL2 expressions are supported in JSON columns.
- *     </code>
+ * </code>
  *     <p>For `GPKG` the following known limitations exist:
  *     <p><code>
  * - The option `linearizeCurves` is not supported. All geometries must conform to the OGC Simple
- *   Feature Access standard.
- * - The CQL2 functions `DIAMETER2D()` and `DIAMETER3D()` are not supported.
- * - Arrays as queryables are not supported for GeoPackage feature providers.
- * - Queryables that are values in an array are not supported for GeoPackage feature providers.
- *     </code>
+ * Feature Access standard. - The CQL2 functions `DIAMETER2D()` and `DIAMETER3D()` are not
+ * supported. - Arrays as queryables are not supported for GeoPackage feature providers. -
+ * Queryables that are values in an array are not supported for GeoPackage feature providers.
+ * </code>
  * @limitationsDe
  *     <p>Alle Bezeichner müssen nicht in Anführungszeichen gesetzt werden, d.h. die Bezeichner
  *     werden klein geschrieben.
  *     <p>Für `PGIS` gibt es die folgenden bekannten Einschränkungen:
  *     <p><code>
  * - Nicht alle CQL2-Ausdrücke werden in JSON-Spalten unterstützt.
- *     </code>
+ * </code>
  *     <p>Für `GPKG` gibt es die folgenden bekannten Einschränkungen:
  *     <p><code>
  * - Die Option `linearizeCurves` wird nicht unterstützt. Alle Geometrien müssen Geometrien gemäß
- *   dem Standard OGC Simple Feature Access sein.
- * - Die CQL2-Funktionen `DIAMETER2D()` und `DIAMETER3D()` werden nicht unterstützt.
- * - Arrays als Queryables werden für GeoPackage Feature Provider nicht unterstützt.
- * - Queryables, die Werte in einem Array sind, werden für GeoPackage Feature-Anbieter nicht
- *   unterstützt.
- *     </code>
+ * dem Standard OGC Simple Feature Access sein. - Die CQL2-Funktionen `DIAMETER2D()` und
+ * `DIAMETER3D()` werden nicht unterstützt. - Arrays als Queryables werden für GeoPackage Feature
+ * Provider nicht unterstützt. - Queryables, die Werte in einem Array sind, werden für GeoPackage
+ * Feature-Anbieter nicht unterstützt.
+ * </code>
  * @cfgPropertiesAdditionalEn ### Connection Info
  *     <p>The connection info object for SQL databases has the following properties:
  *     <p>{@docTable:connectionInfo}
@@ -492,7 +490,8 @@ public class FeatureProviderSql
             crsTransformerFactory,
             crsInfo,
             cql,
-            accentiCollation);
+            accentiCollation,
+            getData().getQueryGeneration().getGeometryAsWkb());
     AggregateStatsQueryGenerator queryGeneratorSql =
         new AggregateStatsQueryGenerator(sqlDialect, filterEncoder);
 
@@ -522,7 +521,8 @@ public class FeatureProviderSql
                                           sqlDialect,
                                           getData().getQueryGeneration().getComputeNumberMatched(),
                                           true,
-                                          getData().getQueryGeneration().getNullOrder())))
+                                          getData().getQueryGeneration().getNullOrder(),
+                                          getData().getQueryGeneration().getGeometryAsWkb())))
                           .collect(Collectors.toList()));
                 })
             .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
@@ -546,7 +546,8 @@ public class FeatureProviderSql
                                         sqlDialect,
                                         getData().getQueryGeneration().getComputeNumberMatched(),
                                         false,
-                                        getData().getQueryGeneration().getNullOrder())))))
+                                        getData().getQueryGeneration().getNullOrder(),
+                                        getData().getQueryGeneration().getGeometryAsWkb())))))
             .collect(ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue));
 
     this.queryTransformer =
@@ -1336,8 +1337,9 @@ public class FeatureProviderSql
 
   @Override
   public boolean supportsAccenti() {
-    if (Objects.nonNull(getData().getQueryGeneration()))
+    if (Objects.nonNull(getData().getQueryGeneration())) {
       return getData().getQueryGeneration().getAccentiCollation().isPresent();
+    }
     return false;
   }
 

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSql.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSql.java
@@ -817,7 +817,8 @@ public class FeatureProviderSql
               ? tableSchemas.get(featureQuery.getType())
               : tableSchemasMutations.get(featureQuery.getType());
 
-      return new FeatureDecoderSql(mappings, schemas, query, subdecoders);
+      return new FeatureDecoderSql(
+          mappings, schemas, query, subdecoders, getData().getQueryGeneration().getGeometryAsWkb());
     }
 
     if (query instanceof MultiFeatureQuery) {
@@ -828,7 +829,8 @@ public class FeatureProviderSql
               .flatMap(typeQuery -> tableSchemas.get(typeQuery.getType()).stream())
               .collect(Collectors.toList());
 
-      return new FeatureDecoderSql(mappings, schemas, query, subdecoders);
+      return new FeatureDecoderSql(
+          mappings, schemas, query, subdecoders, getData().getQueryGeneration().getGeometryAsWkb());
     }
 
     throw new IllegalArgumentException();

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSqlData.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSqlData.java
@@ -190,11 +190,11 @@ public interface FeatureProviderSqlData
     /**
      * @langEn Option to return geometries as Well-Known Binary (WKB) format.
      * @langDe Option, Geometrien im Well-Known Binary (WKB) Format zurückzugeben.
-     * @default true
+     * @default false
      */
     @Value.Default
     default boolean getGeometryAsWkb() {
-      return true;
+      return false;
     }
   }
 

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSqlData.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/FeatureProviderSqlData.java
@@ -186,6 +186,16 @@ public interface FeatureProviderSqlData
     default Optional<String> getAccentiCollation() {
       return Optional.empty();
     }
+
+    /**
+     * @langEn Option to return geometries as Well-Known Binary (WKB) format.
+     * @langDe Option, Geometrien im Well-Known Binary (WKB) Format zurückzugeben.
+     * @default true
+     */
+    @Value.Default
+    default boolean getGeometryAsWkb() {
+      return true;
+    }
   }
 
   @Value.Check
@@ -209,27 +219,31 @@ public interface FeatureProviderSqlData
    * @langEn Defines how dataset changes should be detected. There are the following modes:
    *     <p><code>
    * - `OFF`: The dataset is considered static and no change detection is performed. If there is a
-   *   new dataset version, that should result in changes to `connectionInfo`. (This will be the default in v5.x)
-   * - `CRUD`: Changes to the dataset are exclusively made by the application itself through the CRUD interface. (This is the default in v4.x)
-   * - `TRIGGER`: There are triggers set up for the dataset that notify the application about changes
-   *   (see for example [Change Listener](90-extensions/change_listener.md)). Additionally a periodic synchronization can be configured with `syncPeriodic` for the case of missed notifications.
-   * - `EXTERNAL`: Assume that the dataset may be changed by external applications.
-   *   In this mode a synchronization happens on every provider start or reload.
-   *   Additionally a periodic synchronization can be configured with `syncPeriodic`.
-   *     </code>
+   * new dataset version, that should result in changes to `connectionInfo`. (This will be the
+   * default in v5.x) - `CRUD`: Changes to the dataset are exclusively made by the application
+   * itself through the CRUD interface. (This is the default in v4.x) - `TRIGGER`: There are
+   * triggers set up for the dataset that notify the application about changes (see for example
+   * [Change Listener](90-extensions/change_listener.md)). Additionally a periodic synchronization
+   * can be configured with `syncPeriodic` for the case of missed notifications. - `EXTERNAL`:
+   * Assume that the dataset may be changed by external applications. In this mode a synchronization
+   * happens on every provider start or reload. Additionally a periodic synchronization can be
+   * configured with `syncPeriodic`.
+   * </code>
    * @langDe Definiert wie Änderungen am Datensatz erkannt werden sollen. Es gibt die folgenden
    *     Modi:
    *     <p><code>
-   * - `OFF`: Der Datensatz wird als statisch betrachtet und es wird keine Änderungserkennung durchgeführt.
-   *   Wenn es eine neue Datensatzversion gibt, sollte diese zu Änderungen an `connectionInfo` führen. (Dies wird in v5.x der Standard sein)
-   * - `CRUD`: Änderungen am Datensatz werden ausschließlich von der Anwendung selbst über die CRUD-Schnittstelle vorgenommen. (Dies ist in v4.x der Standard)
-   * - `TRIGGER`: Es sind Trigger für den Datensatz eingerichtet, die die Anwendung über Änderungen informieren
-   *   (siehe z.B. [Change Listener](90-extensions/change_listener.md)). Zusätzlich kann eine
-   *   periodische Synchronisation mit `syncPeriodic` für den Fall von verpassten Benachrichtigungen konfiguriert werden.
-   * - `EXTERNAL`: Annehmen, dass der Datensatz von externen Anwendungen geändert werden kann.
-   *   In diesem Modus erfolgt eine Synchronisation bei jedem Start oder Reload des Providers.
-   *   Zusätzlich kann eine periodische Synchronisation mit `syncPeriodic` konfiguriert werden.
-   *     </code>
+   * - `OFF`: Der Datensatz wird als statisch betrachtet und es wird keine Änderungserkennung
+   * durchgeführt. Wenn es eine neue Datensatzversion gibt, sollte diese zu Änderungen an
+   * `connectionInfo` führen. (Dies wird in v5.x der Standard sein) - `CRUD`: Änderungen am
+   * Datensatz werden ausschließlich von der Anwendung selbst über die CRUD-Schnittstelle
+   * vorgenommen. (Dies ist in v4.x der Standard) - `TRIGGER`: Es sind Trigger für den Datensatz
+   * eingerichtet, die die Anwendung über Änderungen informieren (siehe z.B. [Change
+   * Listener](90-extensions/change_listener.md)). Zusätzlich kann eine periodische Synchronisation
+   * mit `syncPeriodic` für den Fall von verpassten Benachrichtigungen konfiguriert werden. -
+   * `EXTERNAL`: Annehmen, dass der Datensatz von externen Anwendungen geändert werden kann. In
+   * diesem Modus erfolgt eine Synchronisation bei jedem Start oder Reload des Providers. Zusätzlich
+   * kann eine periodische Synchronisation mit `syncPeriodic` konfiguriert werden.
+   * </code>
    */
   @Value.Immutable
   @JsonDeserialize(builder = ImmutableDatasetChangeSettings.Builder.class)
@@ -245,8 +259,8 @@ public interface FeatureProviderSqlData
     /**
      * @langEn The mode for dataset change detection, see above.
      * @langDe Der Modus für die Erkennung von Datensatzänderungen, siehe oben.
-     * @since v4.3
      * @default CRUD v4 \| OFF v5
+     * @since v4.3
      */
     @Value.Default
     default Mode getMode() {
@@ -258,8 +272,8 @@ public interface FeatureProviderSqlData
      *     dataset. Only available for modes `EXTERNAL` and `TRIGGER`.
      * @langDe Ein Crontab-Pattern zum regelmäßigen Aktualisieren aller gecachten Daten, die sich
      *     aus dem Datensatz ableiten. Nur verfügbar für die Modi `EXTERNAL` und `TRIGGER`.
-     * @since v4.3
      * @default null
+     * @since v4.3
      */
     @Nullable
     String getSyncPeriodic();

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialect.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialect.java
@@ -27,6 +27,10 @@ public interface SqlDialect {
 
   String applyToWkt(String wkt, int srid);
 
+  String applyToWkb(String column, boolean forcePolygonCCW, boolean linearizeCurves);
+
+  String applyToWkb(byte[] wkb, int srid);
+
   String applyToExtent(String column, boolean is3d);
 
   String applyToString(String string);

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialectGpkg.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialectGpkg.java
@@ -52,7 +52,7 @@ public class SqlDialectGpkg implements SqlDialect {
 
   @Override
   public String applyToWkb(byte[] wkb, int srid) {
-    return "SDO_UTIL.FROM_WKBGEOMETRY(?, ?)";
+    return String.format("GeomFromWKB('%s', %d)", wkb, srid);
   }
 
   @Override

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialectGpkg.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialectGpkg.java
@@ -11,6 +11,7 @@ import com.google.common.base.Splitter;
 import de.ii.xtraplatform.crs.domain.BoundingBox;
 import de.ii.xtraplatform.crs.domain.EpsgCrs;
 import de.ii.xtraplatform.features.domain.SchemaBase.Type;
+import de.ii.xtraplatform.features.sql.domain.FeatureProviderSqlData.QueryGeneratorSettings;
 import de.ii.xtraplatform.features.sql.domain.SchemaSql.PropertyTypeInfo;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -22,6 +23,8 @@ import java.util.Optional;
 import org.threeten.extra.Interval;
 
 public class SqlDialectGpkg implements SqlDialect {
+
+  private QueryGeneratorSettings settings;
 
   private static final Splitter BBOX_SPLITTER =
       Splitter.onPattern("[(), ]").omitEmptyStrings().trimResults();
@@ -37,6 +40,19 @@ public class SqlDialectGpkg implements SqlDialect {
   @Override
   public String applyToWkt(String wkt, int srid) {
     return String.format("ST_GeomFromText('%s',%s)", wkt, srid);
+  }
+
+  @Override
+  public String applyToWkb(String column, boolean forcePolygonCCW, boolean linearizeCurves) {
+    if (!forcePolygonCCW) {
+      return String.format("ST_AsBinary(%s)", column);
+    }
+    return String.format("ST_AsBinary(ST_ForcePolygonCCW(%s))", column);
+  }
+
+  @Override
+  public String applyToWkb(byte[] wkb, int srid) {
+    return "SDO_UTIL.FROM_WKBGEOMETRY(?, ?)";
   }
 
   @Override
@@ -194,7 +210,9 @@ public class SqlDialectGpkg implements SqlDialect {
     if (!subDecoderPaths.isEmpty()) {
       String expression =
           subDecoderPaths.values().iterator().next().replaceAll("\\$(?:t|T|table)\\$", table);
-      if (spatial) {
+      if (spatial && settings.getGeometryAsWkb()) {
+        expression = applyToWkb(expression, false, false);
+      } else if (spatial) {
         expression = applyToWkt(expression, false, false);
       }
       return String.format("(%s) AS %s", expression, name);

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialectPgis.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialectPgis.java
@@ -72,6 +72,30 @@ public class SqlDialectPgis implements SqlDialect {
   }
 
   @Override
+  public String applyToWkb(String column, boolean forcePolygonCCW, boolean linearizeCurves) {
+    StringBuilder binaryBuilder = new StringBuilder("ST_AsBinary(");
+    if (linearizeCurves) {
+      binaryBuilder.append("ST_CurveToLine(");
+    }
+    if (forcePolygonCCW) {
+      binaryBuilder.append("ST_ForcePolygonCCW(");
+    }
+    binaryBuilder.append(column);
+    if (forcePolygonCCW) {
+      binaryBuilder.append(")");
+    }
+    if (linearizeCurves) {
+      binaryBuilder.append(",32,0,1)");
+    }
+    return binaryBuilder.append(")").toString();
+  }
+
+  @Override
+  public String applyToWkb(byte[] wkb, int srid) {
+    return "SDO_UTIL.FROM_WKBGEOMETRY(?, ?)";
+  }
+
+  @Override
   public String applyToExtent(String column, boolean is3d) {
     return is3d ? String.format("ST_3DExtent(%s)", column) : String.format("ST_Extent(%s)", column);
   }

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialectPgis.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/domain/SqlDialectPgis.java
@@ -92,7 +92,7 @@ public class SqlDialectPgis implements SqlDialect {
 
   @Override
   public String applyToWkb(byte[] wkb, int srid) {
-    return "SDO_UTIL.FROM_WKBGEOMETRY(?, ?)";
+    return String.format("GeomFromWKB('%s', %d)", wkb, srid);
   }
 
   @Override

--- a/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/FeatureDecoderSqlSpec.groovy
+++ b/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/FeatureDecoderSqlSpec.groovy
@@ -8,13 +8,8 @@
 package de.ii.xtraplatform.features.sql.app
 
 import com.google.common.collect.ImmutableList
+import de.ii.xtraplatform.features.domain.*
 import de.ii.xtraplatform.features.sql.domain.SqlRow
-import de.ii.xtraplatform.features.domain.FeatureEventHandler
-import de.ii.xtraplatform.features.domain.FeatureSchema
-import de.ii.xtraplatform.features.domain.FeatureTokenDecoder
-import de.ii.xtraplatform.features.domain.ImmutableFeatureQuery
-import de.ii.xtraplatform.features.domain.ImmutableFeatureSchema
-import de.ii.xtraplatform.features.domain.SchemaMapping
 import de.ii.xtraplatform.features.sql.domain.SqlRowFixtures
 import de.ii.xtraplatform.streams.app.ReactiveRx
 import de.ii.xtraplatform.streams.domain.Reactive
@@ -27,7 +22,8 @@ import spock.lang.Specification
 /**
  * @author zahnen
  */
-@Ignore //TODO: use SchemaSql
+@Ignore
+//TODO: use SchemaSql
 class FeatureDecoderSqlSpec extends Specification {
 
     static final Logger LOGGER = LoggerFactory.getLogger(FeatureDecoderSqlSpec.class)
@@ -55,14 +51,16 @@ class FeatureDecoderSqlSpec extends Specification {
                 new ImmutableFeatureSchema.Builder().name("test").build(),
                 ImmutableFeatureQuery.builder()
                         .type("biotop")
-                        .build())
+                        .build(),
+                false)
         singleDecoder = new FeatureDecoderSql(
                 SqlRowFixtures.TYPE_INFOS, ImmutableList.of(),
                 new ImmutableFeatureSchema.Builder().name("test").build(),
                 ImmutableFeatureQuery.builder()
                         .type("biotop")
                         .returnsSingleFeature(true)
-                        .build())
+                        .build(),
+                false)
     }
 
     public <T> T runStream(Reactive.Stream<T> stream) {

--- a/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/FilterEncoderSqlSpec.groovy
+++ b/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/FilterEncoderSqlSpec.groovy
@@ -33,13 +33,13 @@ class FilterEncoderSqlSpec extends Specification {
 
     def setupSpec() {
 
-        filterEncoder = new FilterEncoderSql(OgcCrs.CRS84, new SqlDialectPgis(), null, null, new CqlImpl(), null)
+        filterEncoder = new FilterEncoderSql(OgcCrs.CRS84, new SqlDialectPgis(), null, null, new CqlImpl(), null, false)
         ResourceStore resourceStore = Stub()
         VolatileRegistry volatileRegistry = Stub()
         volatileRegistry.onAvailable(*_) >> CompletableFuture.completedFuture(null)
         CrsTransformerFactoryProj transformerFactory = new CrsTransformerFactoryProj(new ProjLoaderImpl(Path.of(System.getProperty("java.io.tmpdir"), "proj", "data")), resourceStore, volatileRegistry)
         transformerFactory.onStart(false).toCompletableFuture().join()
-        filterEncoder2 = new FilterEncoderSql(OgcCrs.CRS84, new SqlDialectPgis(), (CrsTransformerFactory) transformerFactory, null, new CqlImpl(), null)
+        filterEncoder2 = new FilterEncoderSql(OgcCrs.CRS84, new SqlDialectPgis(), (CrsTransformerFactory) transformerFactory, null, new CqlImpl(), null, false)
 
     }
 
@@ -228,6 +228,7 @@ class FilterEncoderSqlSpec extends Specification {
         actual == expected
 
     }
+
     def 'temporal operation, interval 3'() {
 
         given:

--- a/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/GeometryDecoderWkbSpec.groovy
+++ b/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/GeometryDecoderWkbSpec.groovy
@@ -1,0 +1,172 @@
+package de.ii.xtraplatform.features.sql.app
+
+import de.ii.xtraplatform.features.domain.FeatureEventHandler
+import de.ii.xtraplatform.features.domain.FeatureEventHandler.ModifiableContext
+import de.ii.xtraplatform.features.domain.SchemaBase.Type
+import de.ii.xtraplatform.geometries.domain.SimpleFeatureGeometry
+import org.locationtech.jts.geom.*
+import org.locationtech.jts.io.WKBWriter
+import spock.lang.Specification
+
+class GeometryDecoderWkbSpec extends Specification {
+
+    GeometryFactory geometryFactory = new GeometryFactory();
+    def handler = Mock(FeatureEventHandler)
+    def context = Mock(ModifiableContext)
+    def decoder = new GeometryDecoderWkb(handler, context)
+    def wkbWriter = new WKBWriter()
+
+    def "test decode POINT"() {
+        given:
+        byte[] wkb = wkbWriter.write(geometryFactory.createPoint(new Coordinate(30, 10)))
+        String expectedToken = "POINT (30 10)"
+
+        when:
+        decoder.decode(wkb)
+
+        then:
+        1 * handler.onObjectStart(context)
+        1 * context.setGeometryType(SimpleFeatureGeometry.POINT)
+        1 * context.setGeometryDimension(3)
+        1 * context.setValueType(Type.STRING)
+        1 * context.setValue(expectedToken)
+        1 * handler.onValue(context)
+        1 * handler.onObjectEnd(context)
+    }
+
+    def "test decode LINESTRING"() {
+        given:
+        byte[] wkb = wkbWriter.write(geometryFactory.createLineString([
+                new Coordinate(10, 10),
+                new Coordinate(20, 20),
+                new Coordinate(30, 40)
+        ] as Coordinate[]))
+        String expectedToken = "LINESTRING (10 10, 20 20, 30 40)"
+
+        when:
+        decoder.decode(wkb)
+
+        then:
+        1 * handler.onObjectStart(context)
+        1 * context.setGeometryType(SimpleFeatureGeometry.LINE_STRING)
+        1 * context.setGeometryDimension(3)
+        1 * context.setValueType(Type.STRING)
+        1 * context.setValue(expectedToken)
+        1 * handler.onValue(context)
+        1 * handler.onObjectEnd(context)
+    }
+
+    def "test decode POLYGON"() {
+        given:
+        byte[] wkb = wkbWriter.write(geometryFactory.createPolygon([
+                new Coordinate(30, 10),
+                new Coordinate(40, 40),
+                new Coordinate(20, 40),
+                new Coordinate(10, 20),
+                new Coordinate(30, 10)
+        ] as Coordinate[]))
+        String expectedToken = "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))"
+
+        when:
+        decoder.decode(wkb)
+
+        then:
+        1 * handler.onObjectStart(context)
+        1 * context.setGeometryType(SimpleFeatureGeometry.POLYGON)
+        1 * context.setGeometryDimension(3)
+        1 * context.setValueType(Type.STRING)
+        1 * context.setValue(expectedToken)
+        1 * handler.onValue(context)
+        1 * handler.onObjectEnd(context)
+    }
+
+    def "test decode MULTIPOINT"() {
+        given:
+        byte[] wkb = wkbWriter.write(geometryFactory.createMultiPoint([
+                geometryFactory.createPoint(new Coordinate(10, 40)),
+                geometryFactory.createPoint(new Coordinate(40, 30)),
+                geometryFactory.createPoint(new Coordinate(20, 20)),
+                geometryFactory.createPoint(new Coordinate(30, 10))
+        ] as Point[]))
+        List<String> expectedTokens = ["POINT (10 40)", "POINT (40 30)", "POINT (20 20)", "POINT (30 10)"]
+
+        when:
+        decoder.decode(wkb)
+
+        then:
+        1 * handler.onObjectStart(context)
+        1 * context.setGeometryType(SimpleFeatureGeometry.MULTI_POINT)
+        1 * context.setGeometryDimension(3)
+        1 * handler.onArrayStart(context)
+        expectedTokens.each { token ->
+            1 * context.setValueType(Type.STRING)
+            1 * context.setValue(token)
+            1 * handler.onValue(context)
+        }
+        1 * handler.onArrayEnd(context)
+        1 * handler.onObjectEnd(context)
+    }
+
+    def "test decode MULTILINESTRING"() {
+        given:
+        byte[] wkb = wkbWriter.write(geometryFactory.createMultiLineString([
+                geometryFactory.createLineString([new Coordinate(10, 10), new Coordinate(20, 20)] as Coordinate[]),
+                geometryFactory.createLineString([new Coordinate(30, 30), new Coordinate(40, 40)] as Coordinate[])
+        ] as LineString[]))
+        List<String> expectedTokens = ["LINESTRING (10 10, 20 20)", "LINESTRING (30 30, 40 40)"]
+
+        when:
+        decoder.decode(wkb)
+
+        then:
+        1 * handler.onObjectStart(context)
+        1 * context.setGeometryType(SimpleFeatureGeometry.MULTI_LINE_STRING)
+        1 * context.setGeometryDimension(3)
+        1 * handler.onArrayStart(context)
+        expectedTokens.each { token ->
+            1 * context.setValueType(Type.STRING)
+            1 * context.setValue(token)
+            1 * handler.onValue(context)
+        }
+        1 * handler.onArrayEnd(context)
+        1 * handler.onObjectEnd(context)
+    }
+
+    def "test decode MULTIPOLYGON"() {
+        given:
+        byte[] wkb = wkbWriter.write(geometryFactory.createMultiPolygon([
+                geometryFactory.createPolygon([
+                        new Coordinate(10, 10),
+                        new Coordinate(20, 20),
+                        new Coordinate(20, 10),
+                        new Coordinate(10, 10)
+                ] as Coordinate[]),
+                geometryFactory.createPolygon([
+                        new Coordinate(30, 30),
+                        new Coordinate(40, 40),
+                        new Coordinate(40, 30),
+                        new Coordinate(30, 30)
+                ] as Coordinate[])
+        ] as Polygon[]))
+        List<String> expectedTokens = [
+                "POLYGON ((10 10, 20 20, 20 10, 10 10))",
+                "POLYGON ((30 30, 40 40, 40 30, 30 30))"
+        ]
+
+        when:
+        decoder.decode(wkb)
+
+        then:
+        1 * handler.onObjectStart(context)
+        1 * context.setGeometryType(SimpleFeatureGeometry.MULTI_POLYGON)
+        1 * context.setGeometryDimension(3)
+        1 * handler.onArrayStart(context)
+        expectedTokens.each { token ->
+            1 * context.setValueType(Type.STRING)
+            1 * context.setValue(token)
+            1 * handler.onValue(context)
+        }
+        1 * handler.onArrayEnd(context)
+        1 * handler.onObjectEnd(context)
+    }
+}

--- a/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/GeometryDecoderWktSpec.groovy
+++ b/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/GeometryDecoderWktSpec.groovy
@@ -119,4 +119,26 @@ class GeometryDecoderWktSpec extends Specification {
         3 * handler.onArrayEnd(context)
         1 * handler.onObjectEnd(context)
     }
+
+    def "test decode MULTILINESTRING"() {
+        given:
+        String wkt = "MULTILINESTRING ((10 10, 20 20), (15 15, 30 15))"
+        List<String> expectedTokens = ["10 10,20 20", "15 15,30 15"]
+
+        when:
+        decoder.decode(wkt)
+
+        then:
+        1 * handler.onObjectStart(context)
+        1 * context.setGeometryType(SimpleFeatureGeometry.MULTI_LINE_STRING)
+        1 * context.setGeometryDimension(2)
+        1 * handler.onArrayStart(context)
+        expectedTokens.each { token ->
+            1 * context.setValueType(Type.STRING)
+            1 * context.setValue(token)
+            1 * handler.onValue(context)
+        }
+        1 * handler.onArrayEnd(context)
+        1 * handler.onObjectEnd(context)
+    }
 }

--- a/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/GeometryDecoderWktSpec.groovy
+++ b/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/GeometryDecoderWktSpec.groovy
@@ -1,0 +1,122 @@
+package de.ii.xtraplatform.features.sql.app
+
+import de.ii.xtraplatform.features.domain.FeatureEventHandler
+import de.ii.xtraplatform.features.domain.FeatureEventHandler.ModifiableContext
+import de.ii.xtraplatform.features.domain.FeatureSchema
+import de.ii.xtraplatform.features.domain.SchemaBase.Type
+import de.ii.xtraplatform.features.domain.SchemaMapping
+import de.ii.xtraplatform.geometries.domain.SimpleFeatureGeometry
+import spock.lang.Specification
+
+class GeometryDecoderWktSpec extends Specification {
+
+    FeatureEventHandler<FeatureSchema, SchemaMapping, ModifiableContext<FeatureSchema, SchemaMapping>> handler
+    ModifiableContext<FeatureSchema, SchemaMapping> context
+    GeometryDecoderWkt decoder
+
+    def setup() {
+        handler = Mock(FeatureEventHandler)
+        context = Mock(ModifiableContext)
+        decoder = new GeometryDecoderWkt(handler, context)
+    }
+
+    def "test decode POINT"() {
+        given:
+        String wkt = "POINT (30 10)"
+        String expectedToken = "30 10"
+
+        when:
+        decoder.decode(wkt)
+
+        then:
+        1 * handler.onObjectStart(context)
+        1 * context.setGeometryType(SimpleFeatureGeometry.POINT)
+        1 * context.setGeometryDimension(2)
+        1 * context.setValueType(Type.STRING)
+        1 * context.setValue(expectedToken)
+        1 * handler.onValue(context)
+        1 * handler.onObjectEnd(context)
+    }
+
+    def "test decode POLYGON"() {
+        given:
+        String wkt = "POLYGON ((30 10, 40 40, 20 40, 10 20, 30 10))"
+        String expectedToken = "30 10,40 40,20 40,10 20,30 10"
+
+        when:
+        decoder.decode(wkt)
+
+        then:
+        1 * handler.onObjectStart(context)
+        1 * context.setGeometryType(SimpleFeatureGeometry.POLYGON)
+        1 * context.setGeometryDimension(2)
+        1 * context.setValueType(Type.STRING)
+        1 * context.setValue(expectedToken)
+        1 * handler.onValue(context)
+        1 * handler.onArrayStart(context)
+        1 * handler.onArrayEnd(context)
+        1 * handler.onObjectEnd(context)
+    }
+
+    def "test decode MULTIPOINT"() {
+        given:
+        String wkt = "MULTIPOINT ((10 40), (40 30), (20 20), (30 10))"
+        List<String> expectedTokens = ["10 40", "40 30", "20 20", "30 10"]
+
+        when:
+        decoder.decode(wkt)
+
+        then:
+        1 * handler.onObjectStart(context)
+        1 * context.setGeometryType(SimpleFeatureGeometry.MULTI_POINT)
+        1 * context.setGeometryDimension(2)
+        1 * handler.onArrayStart(context)
+        expectedTokens.each { token ->
+            1 * context.setValueType(Type.STRING)
+            1 * context.setValue(token)
+            1 * handler.onValue(context)
+        }
+        1 * handler.onArrayEnd(context)
+        1 * handler.onObjectEnd(context)
+    }
+
+    def "test decode LINESTRING"() {
+        given:
+        String wkt = "LINESTRING (30 10, 10 30, 40 40)"
+        String expectedToken = "30 10,10 30,40 40"
+
+        when:
+        decoder.decode(wkt)
+
+        then:
+        1 * handler.onObjectStart(context)
+        1 * context.setGeometryType(SimpleFeatureGeometry.LINE_STRING)
+        1 * context.setGeometryDimension(2)
+        1 * context.setValueType(Type.STRING)
+        1 * context.setValue(expectedToken)
+        1 * handler.onValue(context)
+        1 * handler.onObjectEnd(context)
+    }
+
+    def "test decode MULTIPOLYGON"() {
+        given:
+        String wkt = "MULTIPOLYGON (((30 20, 45 40, 10 40, 30 20)), ((15 5, 40 10, 10 20, 5 10, 15 5)))"
+        List<String> expectedTokens = ["30 20,45 40,10 40,30 20", "15 5,40 10,10 20,5 10,15 5"]
+
+        when:
+        decoder.decode(wkt)
+
+        then:
+        1 * handler.onObjectStart(context)
+        1 * context.setGeometryType(SimpleFeatureGeometry.MULTI_POLYGON)
+        1 * context.setGeometryDimension(2)
+        3 * handler.onArrayStart(context)
+        expectedTokens.each { token ->
+            1 * context.setValueType(Type.STRING)
+            1 * context.setValue(token)
+            1 * handler.onValue(context)
+        }
+        3 * handler.onArrayEnd(context)
+        1 * handler.onObjectEnd(context)
+    }
+}

--- a/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/SqlQueryTemplatesDeriverSpec.groovy
+++ b/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/SqlQueryTemplatesDeriverSpec.groovy
@@ -30,6 +30,11 @@ class SqlQueryTemplatesDeriverSpec extends Specification {
     SqlQueryTemplatesDeriver tdNoNm = new SqlQueryTemplatesDeriver(null, filterEncoder, new SqlDialectPgis(), false, false, Optional.empty(), false)
 
     @Shared
+    SqlQueryTemplatesDeriver tdWkb = new SqlQueryTemplatesDeriver(null, filterEncoder, new SqlDialectPgis(), true, false, Optional.empty(), true)
+    @Shared
+    SqlQueryTemplatesDeriver tdNoNmWkb = new SqlQueryTemplatesDeriver(null, filterEncoder, new SqlDialectPgis(), false, false, Optional.empty(), true)
+
+    @Shared
     QuerySchemaDeriver schemaDeriver
     @Shared
     MappingOperationResolver mappingOperationResolver
@@ -117,6 +122,82 @@ class SqlQueryTemplatesDeriverSpec extends Specification {
         "self join with nested duplicate and filters" | td      | 0     | 0      | []     | null   | "okstra_abschnitt"            || "okstra_abschnitt"
         "embedded object with concat and backlink"    | td      | 0     | 0      | []     | null   | "pfs_plan-hatObjekt-embedded" || "pfs_plan-hatObjekt-embedded"
         "root concat with value concat with constant" | td      | 0     | 0      | []     | null   | "landcoverunit"               || "landcoverunit"
+
+    }
+
+    def 'meta query templates with WKB: #casename'() {
+
+        when:
+
+        SqlQueryTemplates templates = source.get(0).accept(deriver)
+        String actual = meta(templates, sortBy, userFilter)
+
+        then:
+
+        actual == expected
+
+        where:
+
+        casename                      | deriver   | sortBy                                                                            | userFilter | source                            || expected
+        "basic"                       | tdWkb     | []                                                                                | noFilter   | QuerySchemaFixtures.SIMPLE        || SqlQueryTemplatesFixtures.META
+        "basic without numberMatched" | tdNoNmWkb | []                                                                                | noFilter   | QuerySchemaFixtures.SIMPLE        || SqlQueryTemplatesFixtures.META_WITHOUT_NUMBER_MATCHED
+        "sortBy"                      | tdWkb     | [SortKey.of("created")]                                                           | noFilter   | QuerySchemaFixtures.SIMPLE        || SqlQueryTemplatesFixtures.META_SORT_BY
+        "sortBy descending"           | tdWkb     | [SortKey.of("created", SortKey.Direction.DESCENDING)]                             | noFilter   | QuerySchemaFixtures.SIMPLE        || SqlQueryTemplatesFixtures.META_SORT_BY_DESC
+        "sortBy mixed"                | tdWkb     | [SortKey.of("created", SortKey.Direction.DESCENDING), SortKey.of("lastModified")] | noFilter   | QuerySchemaFixtures.SIMPLE        || SqlQueryTemplatesFixtures.META_SORT_BY_MIXED
+        "filter"                      | tdWkb     | []                                                                                | noFilter   | QuerySchemaFixtures.SIMPLE_FILTER || SqlQueryTemplatesFixtures.META_FILTER
+    }
+
+    def 'value query templates with WKB: #casename'() {
+
+        when:
+
+        SqlQueryTemplates templates = source.get(0).accept(deriver)
+        List<String> actual = values(templates, limit, offset, sortBy, filter)
+
+        then:
+
+        actual == expected
+
+        where:
+
+        casename                             | deriver | limit | offset | sortBy                  | filter                                                                                                                      | source                                                  || expected
+        "value array"                        | tdWkb   | 0     | 0      | []                      | null                                                                                                                        | QuerySchemaFixtures.VALUE_ARRAY                         || SqlQueryTemplatesFixtures.VALUE_ARRAY
+        "object array"                       | tdWkb   | 0     | 0      | []                      | null                                                                                                                        | QuerySchemaFixtures.OBJECT_ARRAY                        || SqlQueryTemplatesFixtures.OBJECT_ARRAY
+        "merge"                              | tdWkb   | 0     | 0      | []                      | null                                                                                                                        | QuerySchemaFixtures.MERGE                               || SqlQueryTemplatesFixtures.MERGE
+        "self joins"                         | tdWkb   | 0     | 0      | []                      | null                                                                                                                        | QuerySchemaFixtures.SELF_JOINS                          || SqlQueryTemplatesFixtures.SELF_JOINS
+        "self joins with filters"            | tdWkb   | 0     | 0      | []                      | null                                                                                                                        | QuerySchemaFixtures.SELF_JOINS_FILTER                   || SqlQueryTemplatesFixtures.SELF_JOINS_FILTER
+        "self join with nested duplicate"    | tdWkb   | 0     | 0      | []                      | null                                                                                                                        | QuerySchemaFixtures.SELF_JOIN_NESTED_DUPLICATE          || SqlQueryTemplatesFixtures.SELF_JOIN_NESTED_DUPLICATE
+        "object without sourcePath"          | tdWkb   | 0     | 0      | []                      | null                                                                                                                        | QuerySchemaFixtures.OBJECT_WITHOUT_SOURCE_PATH          || SqlQueryTemplatesFixtures.OBJECT_WITHOUT_SOURCE_PATH
+        "paging"                             | tdWkb   | 10    | 10     | []                      | null                                                                                                                        | QuerySchemaFixtures.OBJECT_ARRAY                        || SqlQueryTemplatesFixtures.OBJECT_ARRAY_PAGING
+        "sortBy"                             | tdWkb   | 0     | 0      | [SortKey.of("created")] | null                                                                                                                        | QuerySchemaFixtures.OBJECT_ARRAY                        || SqlQueryTemplatesFixtures.OBJECT_ARRAY_SORTBY
+        "sortBy + filter"                    | tdWkb   | 0     | 0      | [SortKey.of("created")] | Eq.of(Property.of("task.title"), ScalarLiteral.of("foo"))                                                                   | QuerySchemaFixtures.OBJECT_ARRAY                        || SqlQueryTemplatesFixtures.OBJECT_ARRAY_SORTBY_FILTER
+        "sortBy + paging"                    | tdWkb   | 10    | 10     | [SortKey.of("created")] | null                                                                                                                        | QuerySchemaFixtures.OBJECT_ARRAY                        || SqlQueryTemplatesFixtures.OBJECT_ARRAY_SORTBY_PAGING
+        "sortBy + paging + filter"           | tdWkb   | 10    | 10     | [SortKey.of("created")] | And.of(Eq.of(Property.of("task.title"), ScalarLiteral.of("foo")), Eq.of(Property.of("task.href"), ScalarLiteral.of("bar"))) | QuerySchemaFixtures.OBJECT_ARRAY                        || SqlQueryTemplatesFixtures.OBJECT_ARRAY_SORTBY_PAGING_FILTER
+        "property with multiple sourcePaths" | tdWkb   | 0     | 0      | []                      | null                                                                                                                        | QuerySchemaFixtures.PROPERTY_WITH_MULTIPLE_SOURCE_PATHS || SqlQueryTemplatesFixtures.PROPERTY_WITH_MULTIPLE_SOURCE_PATHS
+        "nested joins"                       | tdWkb   | 0     | 0      | []                      | null                                                                                                                        | QuerySchemaFixtures.NESTED_JOINS                        || SqlQueryTemplatesFixtures.NESTED_JOINS
+        "nested joins"                       | tdWkb   | 0     | 0      | []                      | null                                                                                                                        | QuerySchemaFixtures.NESTED_JOINS                        || SqlQueryTemplatesFixtures.NESTED_JOINS
+
+    }
+
+    def 'value query templates too with WKB: #casename'() {
+
+        when:
+
+        def sources = sqlSchemas(schema, schemaDeriver, mappingOperationResolver)
+        List<SqlQueryTemplates> templates = sources.collect { it.accept(deriver) }
+        List<String> actual = templates.collectMany { values(it, limit, offset, sortBy, filter) }
+        List<String> expected = SqlQueryFixtures.fromYaml(queries)
+
+        then:
+
+        actual == expected
+
+        where:
+
+        casename                                      | deriver | limit | offset | sortBy | filter | schema                        || queries
+        "self join with nested duplicate and filters" | tdWkb   | 0     | 0      | []     | null   | "okstra_abschnitt"            || "okstra_abschnitt"
+        "embedded object with concat and backlink"    | tdWkb   | 0     | 0      | []     | null   | "pfs_plan-hatObjekt-embedded" || "pfs_plan-hatObjekt-embedded"
+        "root concat with value concat with constant" | tdWkb   | 0     | 0      | []     | null   | "landcoverunit"               || "landcoverunit"
 
     }
 

--- a/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/SqlQueryTemplatesDeriverSpec.groovy
+++ b/xtraplatform-features-sql/src/test/groovy/de/ii/xtraplatform/features/sql/app/SqlQueryTemplatesDeriverSpec.groovy
@@ -16,22 +16,18 @@ import de.ii.xtraplatform.features.domain.MappingOperationResolver
 import de.ii.xtraplatform.features.domain.SortKey
 import de.ii.xtraplatform.features.domain.Tuple
 import de.ii.xtraplatform.features.json.app.DecoderFactoryJson
-import de.ii.xtraplatform.features.sql.domain.ConstantsResolver
-import de.ii.xtraplatform.features.sql.domain.ImmutableSqlPathDefaults
-import de.ii.xtraplatform.features.sql.domain.SchemaSql
-import de.ii.xtraplatform.features.sql.domain.SqlDialectPgis
-import de.ii.xtraplatform.features.sql.domain.SqlPathParser
+import de.ii.xtraplatform.features.sql.domain.*
 import spock.lang.Shared
 import spock.lang.Specification
 
 class SqlQueryTemplatesDeriverSpec extends Specification {
 
     @Shared
-    FilterEncoderSql filterEncoder = new FilterEncoderSql(OgcCrs.CRS84, new SqlDialectPgis(), null, null, new CqlImpl(), null)
+    FilterEncoderSql filterEncoder = new FilterEncoderSql(OgcCrs.CRS84, new SqlDialectPgis(), null, null, new CqlImpl(), null, false)
     @Shared
-    SqlQueryTemplatesDeriver td = new SqlQueryTemplatesDeriver(null, filterEncoder, new SqlDialectPgis(), true, false, Optional.empty())
+    SqlQueryTemplatesDeriver td = new SqlQueryTemplatesDeriver(null, filterEncoder, new SqlDialectPgis(), true, false, Optional.empty(), false)
     @Shared
-    SqlQueryTemplatesDeriver tdNoNm = new SqlQueryTemplatesDeriver(null, filterEncoder, new SqlDialectPgis(), false, false, Optional.empty())
+    SqlQueryTemplatesDeriver tdNoNm = new SqlQueryTemplatesDeriver(null, filterEncoder, new SqlDialectPgis(), false, false, Optional.empty(), false)
 
     @Shared
     QuerySchemaDeriver schemaDeriver
@@ -107,7 +103,7 @@ class SqlQueryTemplatesDeriverSpec extends Specification {
         when:
 
         def sources = sqlSchemas(schema, schemaDeriver, mappingOperationResolver)
-        List<SqlQueryTemplates> templates = sources.collect {it.accept(deriver) }
+        List<SqlQueryTemplates> templates = sources.collect { it.accept(deriver) }
         List<String> actual = templates.collectMany { values(it, limit, offset, sortBy, filter) }
         List<String> expected = SqlQueryFixtures.fromYaml(queries)
 


### PR DESCRIPTION
This PR enables the generation of geometry as WKB (Well-Known Binary). By default, this feature is disabled. To enable it, you need to set the following configuration:

```yaml
queryGeneration:
  geometryAsWkb: true