### PR TITLE
Set default roles in new resolver

### DIFF
--- a/xtraplatform-features-oracle/src/main/java/de/ii/xtraplatform/features/oracle/app/FeatureProviderOracleFactory.java
+++ b/xtraplatform-features-oracle/src/main/java/de/ii/xtraplatform/features/oracle/app/FeatureProviderOracleFactory.java
@@ -27,6 +27,7 @@ import de.ii.xtraplatform.features.domain.ProviderData;
 import de.ii.xtraplatform.features.domain.SchemaFragmentResolver;
 import de.ii.xtraplatform.features.domain.SchemaReferenceResolver;
 import de.ii.xtraplatform.features.domain.TypesResolver;
+import de.ii.xtraplatform.features.domain.transform.DefaultRolesResolver;
 import de.ii.xtraplatform.features.domain.transform.FeatureRefEmbedder;
 import de.ii.xtraplatform.features.domain.transform.FeatureRefResolver;
 import de.ii.xtraplatform.features.domain.transform.ImplicitMappingResolver;
@@ -160,7 +161,8 @@ public class FeatureProviderOracleFactory
               new ImplicitMappingResolver(),
               new ConstantsResolver(),
               new LabelTemplateResolver(data.getLabelTemplate()),
-              new MappingOperationResolver());
+              new MappingOperationResolver(),
+              new DefaultRolesResolver());
 
       for (TypesResolver resolver : resolvers) {
         data = applyTypesResolver(data, resolver);

--- a/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/FeatureProviderSqlFactory.java
+++ b/xtraplatform-features-sql/src/main/java/de/ii/xtraplatform/features/sql/app/FeatureProviderSqlFactory.java
@@ -28,6 +28,7 @@ import de.ii.xtraplatform.features.domain.ProviderData;
 import de.ii.xtraplatform.features.domain.SchemaFragmentResolver;
 import de.ii.xtraplatform.features.domain.SchemaReferenceResolver;
 import de.ii.xtraplatform.features.domain.TypesResolver;
+import de.ii.xtraplatform.features.domain.transform.DefaultRolesResolver;
 import de.ii.xtraplatform.features.domain.transform.FeatureRefEmbedder;
 import de.ii.xtraplatform.features.domain.transform.FeatureRefResolver;
 import de.ii.xtraplatform.features.domain.transform.ImplicitMappingResolver;
@@ -199,7 +200,8 @@ public class FeatureProviderSqlFactory
               new ImplicitMappingResolver(),
               new ConstantsResolver(),
               new LabelTemplateResolver(data.getLabelTemplate()),
-              new MappingOperationResolver());
+              new MappingOperationResolver(),
+              new DefaultRolesResolver());
 
       for (TypesResolver resolver : resolvers) {
         data = applyTypesResolver(data, resolver);

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureSchema.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/FeatureSchema.java
@@ -22,7 +22,6 @@ import de.ii.xtraplatform.entities.domain.maptobuilder.encoding.BuildableMapEnco
 import de.ii.xtraplatform.features.domain.transform.PropertyTransformation;
 import de.ii.xtraplatform.geometries.domain.SimpleFeatureGeometry;
 import java.util.AbstractMap.SimpleEntry;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -774,112 +773,6 @@ public interface FeatureSchema
                     getName());
               });
     }
-  }
-
-  @Value.Check
-  default FeatureSchema primaryGeometry() {
-    if (isFeature()
-        && getPrimaryGeometry().isPresent()
-        && getPrimaryGeometry().filter(FeatureSchema::isPrimaryGeometry).isEmpty()) {
-      FeatureSchema primaryGeometry = getPrimaryGeometry().get();
-      ImmutableFeatureSchema.Builder builder =
-          new ImmutableFeatureSchema.Builder().from(this).propertyMap(new HashMap<>());
-
-      getPropertyMap()
-          .forEach(
-              (name, property) -> {
-                if (property.isSpatial()
-                    && Objects.equals(property.getName(), primaryGeometry.getName())) {
-                  builder.putPropertyMap(
-                      name,
-                      new ImmutableFeatureSchema.Builder()
-                          .from(property)
-                          .role(Role.PRIMARY_GEOMETRY)
-                          .build());
-                } else {
-                  builder.putPropertyMap(name, property);
-                }
-              });
-
-      return builder.build();
-    }
-
-    return this;
-  }
-
-  @Value.Check
-  default FeatureSchema primaryInstant() {
-    if (isFeature()
-        && getPrimaryInstant().isPresent()
-        && getPrimaryInstant().filter(FeatureSchema::isPrimaryInstant).isEmpty()) {
-      FeatureSchema primaryInstant = getPrimaryInstant().get();
-      ImmutableFeatureSchema.Builder builder =
-          new ImmutableFeatureSchema.Builder().from(this).propertyMap(new HashMap<>());
-
-      getPropertyMap()
-          .forEach(
-              (name, property) -> {
-                if (property.isTemporal()
-                    && Objects.equals(property.getName(), primaryInstant.getName())) {
-                  builder.putPropertyMap(
-                      name,
-                      new ImmutableFeatureSchema.Builder()
-                          .from(property)
-                          .role(Role.PRIMARY_INSTANT)
-                          .build());
-                } else {
-                  builder.putPropertyMap(name, property);
-                }
-              });
-
-      return builder.build();
-    }
-
-    return this;
-  }
-
-  @Value.Check
-  default FeatureSchema primaryInterval() {
-    if (isFeature()
-        && getPrimaryInterval().isPresent()
-        && getPrimaryInterval()
-            .filter(
-                interval ->
-                    interval.first().isPrimaryIntervalStart()
-                        && interval.second().isPrimaryIntervalEnd())
-            .isEmpty()) {
-      Tuple<FeatureSchema, FeatureSchema> primaryInterval = getPrimaryInterval().get();
-      ImmutableFeatureSchema.Builder builder =
-          new ImmutableFeatureSchema.Builder().from(this).propertyMap(new HashMap<>());
-
-      getPropertyMap()
-          .forEach(
-              (name, property) -> {
-                if (property.isTemporal()
-                    && Objects.equals(property.getName(), primaryInterval.first().getName())) {
-                  builder.putPropertyMap(
-                      name,
-                      new ImmutableFeatureSchema.Builder()
-                          .from(property)
-                          .role(Role.PRIMARY_INTERVAL_START)
-                          .build());
-                } else if (property.isTemporal()
-                    && Objects.equals(property.getName(), primaryInterval.second().getName())) {
-                  builder.putPropertyMap(
-                      name,
-                      new ImmutableFeatureSchema.Builder()
-                          .from(property)
-                          .role(Role.PRIMARY_INTERVAL_END)
-                          .build());
-                } else {
-                  builder.putPropertyMap(name, property);
-                }
-              });
-
-      return builder.build();
-    }
-
-    return this;
   }
 
   @Value.Check

--- a/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/DefaultRolesResolver.java
+++ b/xtraplatform-features/src/main/java/de/ii/xtraplatform/features/domain/transform/DefaultRolesResolver.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 interactive instruments GmbH
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package de.ii.xtraplatform.features.domain.transform;
+
+import de.ii.xtraplatform.features.domain.FeatureSchema;
+import de.ii.xtraplatform.features.domain.ImmutableFeatureSchema;
+import de.ii.xtraplatform.features.domain.SchemaBase.Role;
+import de.ii.xtraplatform.features.domain.TypesResolver;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public class DefaultRolesResolver implements TypesResolver {
+
+  @Override
+  public boolean needsResolving(
+      FeatureSchema property, boolean isFeature, boolean isInConcat, boolean isInCoalesce) {
+    return isFeature
+        && ((property.getPrimaryGeometry().isPresent()
+                && property.getPrimaryGeometry().filter(FeatureSchema::isPrimaryGeometry).isEmpty())
+            || (property.getPrimaryInstant().isPresent()
+                && property.getPrimaryInstant().filter(FeatureSchema::isPrimaryInstant).isEmpty()));
+  }
+
+  @Override
+  public FeatureSchema resolve(FeatureSchema property, List<FeatureSchema> parents) {
+    Optional<FeatureSchema> primaryGeometry = property.getPrimaryGeometry();
+    Optional<FeatureSchema> primaryInstant = property.getPrimaryInstant();
+
+    ImmutableFeatureSchema.Builder builder =
+        new ImmutableFeatureSchema.Builder().from(property).propertyMap(new HashMap<>());
+
+    property
+        .getPropertyMap()
+        .forEach(
+            (name, prop) -> {
+              if (primaryGeometry.isPresent()
+                  && prop.isSpatial()
+                  && Objects.equals(prop.getName(), primaryGeometry.get().getName())) {
+                builder.putPropertyMap(
+                    name,
+                    new ImmutableFeatureSchema.Builder()
+                        .from(prop)
+                        .role(Role.PRIMARY_GEOMETRY)
+                        .build());
+              } else if (primaryInstant.isPresent()
+                  && prop.isTemporal()
+                  && Objects.equals(prop.getName(), primaryInstant.get().getName())) {
+                builder.putPropertyMap(
+                    name,
+                    new ImmutableFeatureSchema.Builder()
+                        .from(prop)
+                        .role(Role.PRIMARY_INSTANT)
+                        .build());
+              } else {
+                builder.putPropertyMap(name, prop);
+              }
+            });
+
+    return builder.build();
+  }
+}


### PR DESCRIPTION
This pull request removes the checks in FeatureSchema that explicitly set PRIMARY_GEOMETRY, PRIMARY_INSTANT, PRIMARY_INTERVAL_START, and PRIMARY_INTERVAL_END roles.

Instead a new TypesResolver (DefaultRolesResolver) is executed as the final step during hydration of the SQL/Oracle providers. If no primary geometry is explicitly set, the first spatial property is assigned this role. If no primary instant or interval is explicitly set, the first temporal property is assigned this role.

Note that other roles including the primary interval start or end are only applied, if explicitly set in the provider schema.

Closes https://github.com/ldproxy/ldproxy/issues/1412
